### PR TITLE
fix errors with gnome-49

### DIFF
--- a/convenience.js
+++ b/convenience.js
@@ -24,9 +24,6 @@
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-import GIRepository from 'gi://GIRepository';
-GIRepository.Repository.prepend_search_path("/usr/lib/gnome-shell");
-GIRepository.Repository.prepend_library_path("/usr/lib/gnome-shell");
 import GLib from 'gi://GLib';
 
 export function getSchemaData(Settings) {

--- a/metadata.json
+++ b/metadata.json
@@ -3,12 +3,7 @@
   "disable-extension-version-validation": true,
   "name": "Run or raise",
   "settings-schema": "org.gnome.shell.extensions.run-or-raise",
-  "shell-version": [
-    "45",
-    "46",
-    "47",
-    "48"
-  ],
+  "shell-version": ["45", "46", "47", "48", "49"],
   "url": "https://github.com/CZ-NIC/run-or-raise",
   "uuid": "run-or-raise@edvard.cz"
 }


### PR DESCRIPTION
It's no longer necessary, apparently, to run prepend_search_path for
/usr/lib/gnome-shell/; it's already done?

gnome-49 no longer supports GIRepository.Repository.prepend_search_path and it
works fine without it
